### PR TITLE
feat: add unit tests for Tag, Category, and Author services (#13)

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,33 @@
+Role: Senior Pair Programmer specialized in Hybrid Stack (.NET Ecosystem + Python AI).
+
+User Profile (Me):
+I am a pragmatic Full-Stack Developer. I value working code over "perfect" architecture. I maintain legacy systems while building modern AI tools.
+
+Your Coding Guidelines (STRICTLY FOLLOW):
+
+1. **The .NET / C# Doctrine (Backend Workhorse):**
+   - **Style:** Pragmatic. Use `var` for implicit typing. Prefer readability (`foreach` loops) over complex/unreadable LINQ query syntax.
+   - **Data Handling:** I often handle raw JSON payloads. If I paste a JSON error, assume it's a **Model Binding Issue** in the Controller. Check property names and data types first.
+   - **Error Handling:** Standard `try-catch`. No over-engineered custom exceptions.
+   - **Test Data Context (Enterprise):** Use **Indonesian Names/Strings** for dummy data (e.g., "Laporan Keuangan", "Budi Santoso", "Loker Jakarta") instead of generic English names like "Test Name" or "John Doe".
+
+2. **The Frontend Doctrine (Legacy is King):**
+   - **AJAX:** ALWAYS use `$.ajax` (jQuery). NEVER suggest `fetch` or `axios` unless I explicitly ask for a modern rewrite.
+   - **DOM:** Use jQuery selectors (`$('#id')`).
+   - **UI:** I stick to Bootstrap/Razor Views. Don't suggest moving to React/Vue for existing .NET projects.
+
+3. **The Modern/AI Doctrine (Experimental):**
+   - **Python:** I use Streamlit for quick dashboards and AI wrapping (Ollama/Gemini). Keep the code flat and script-like.
+   - **Nuxt:** I am exploring Nuxt 4. For this, you can use modern practices (Composition API).
+
+4. **"Anti-AI" Coding Signature (Make it look Human):**
+   - **No Fluff:** Do not add comments like `// Initialize variable` or `// Return result`. Only comment on complex logic.
+   - **Variable Names:** Short and effective (e.g., `var data` is fine, no need for `var customerTransactionResponseData`).
+   - **Structure:** It's okay to have a slightly long method if it keeps the logic in one place. Don't break functions into tiny pieces unnecessarily.
+
+5. **Communication:**
+   - **Tone:** Casual Indonesian (Santai/Gue-Lo style).
+   - **Focus:** Skip the intro. Go straight to the code fix or solution.
+
+**Current Context:**
+I am ready to code. Wait for my snippet or question.

--- a/tests/Lexicon.Application.Tests/Lexicon.Application.Tests.csproj
+++ b/tests/Lexicon.Application.Tests/Lexicon.Application.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Lexicon.Application.Tests/Services/AuthorServiceTests.cs
+++ b/tests/Lexicon.Application.Tests/Services/AuthorServiceTests.cs
@@ -1,0 +1,143 @@
+using FluentAssertions;
+using Lexicon.Application.DTOs;
+using Lexicon.Application.Services;
+using Lexicon.Domain.Entities;
+using Lexicon.Domain.Interfaces;
+using Moq;
+using Xunit;
+
+namespace Lexicon.Application.Tests.Services;
+
+public class AuthorServiceTests
+{
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IAuthorRepository> _authorRepositoryMock;
+    private readonly AuthorService _sut;
+
+    public AuthorServiceTests()
+    {
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _authorRepositoryMock = new Mock<IAuthorRepository>();
+
+        _unitOfWorkMock.Setup(u => u.Authors).Returns(_authorRepositoryMock.Object);
+
+        _sut = new AuthorService(_unitOfWorkMock.Object);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ShouldReturnAllAuthors()
+    {
+        // Arrange
+        var authors = new List<Author>
+        {
+            new() { Id = Guid.NewGuid(), Name = "Author 1", Email = "a1@test.com" },
+            new() { Id = Guid.NewGuid(), Name = "Author 2", Email = "a2@test.com" }
+        };
+
+        _authorRepositoryMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(authors);
+
+        // Act
+        var result = await _sut.GetAllAsync();
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.First().Name.Should().Be("Author 1");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ShouldReturnAuthor_WhenFound()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var author = new Author { Id = id, Name = "Test Author", Email = "test@test.com" };
+
+        _authorRepositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(author);
+
+        // Act
+        var result = await _sut.GetByIdAsync(id);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(id);
+        result.Email.Should().Be("test@test.com");
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldCreateAuthor()
+    {
+        // Arrange
+        var dto = new CreateAuthorDto("New Author", "new@test.com", "Bio", "https://avatar.url");
+
+        // Act
+        var result = await _sut.CreateAsync(dto);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Name.Should().Be("New Author");
+        result.Email.Should().Be("new@test.com");
+
+        _authorRepositoryMock.Verify(r => r.AddAsync(It.IsAny<Author>(), It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ShouldUpdateAuthor_WhenFound()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var author = new Author { Id = id, Name = "Old Name", Email = "old@test.com" };
+        var dto = new UpdateAuthorDto("Updated Name", "updated@test.com", "New Bio", "https://new.url");
+
+        _authorRepositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(author);
+
+        // Act
+        var result = await _sut.UpdateAsync(id, dto);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("Updated Name");
+        result.Email.Should().Be("updated@test.com");
+
+        _authorRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<Author>(), It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ShouldReturnTrue_WhenFound()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var author = new Author { Id = id, Name = "To Delete" };
+
+        _authorRepositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(author);
+
+        // Act
+        var result = await _sut.DeleteAsync(id);
+
+        // Assert
+        result.Should().BeTrue();
+        _authorRepositoryMock.Verify(r => r.DeleteAsync(author, It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ShouldReturnFalse_WhenNotFound()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+
+        _authorRepositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Author?)null);
+
+        // Act
+        var result = await _sut.DeleteAsync(id);
+
+        // Assert
+        result.Should().BeFalse();
+        _authorRepositoryMock.Verify(r => r.DeleteAsync(It.IsAny<Author>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/tests/Lexicon.Application.Tests/Services/AuthorServiceTests.cs
+++ b/tests/Lexicon.Application.Tests/Services/AuthorServiceTests.cs
@@ -24,72 +24,87 @@ public class AuthorServiceTests
     }
 
     [Fact]
-    public async Task GetAllAsync_ShouldReturnAllAuthors()
+    public async Task When_GetAll_Should_ReturnDaftarPenulis()
     {
-        var authors = new List<Author> { CreateAuthor("Author 1"), CreateAuthor("Author 2") };
+        var authors = new List<Author> { CreateAuthor("Eko Kurniawan"), CreateAuthor("Sandhika Galih") };
         _authorRepoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(authors);
 
         var result = await _authorService.GetAllAsync();
 
         result.Should().HaveCount(2);
-        Assert.Equal("Author 1", result.First().Name);
+        result.First().Name.Should().Be("Eko Kurniawan");
     }
 
     [Fact]
-    public async Task GetByIdAsync_ShouldReturnAuthor_WhenFound()
+    public async Task When_GetById_Found_Should_ReturnDataPenulis()
     {
-        var author = CreateAuthor("Test Author");
+        var author = CreateAuthor("Budi Santoso");
         _authorRepoMock.Setup(r => r.GetByIdAsync(author.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(author);
 
         var result = await _authorService.GetByIdAsync(author.Id);
 
-        Assert.NotNull(result);
-        result.Email.Should().Be(author.Email);
+        result.Should().NotBeNull();
+        result!.Email.Should().Be("budi.santoso@contoh.com");
     }
 
     [Fact]
-    public async Task CreateAsync_ShouldCreateAuthor()
+    public async Task When_Create_WithValidData_Should_SimpanDanReturnDto()
     {
-        var dto = new CreateAuthorDto("New Author", "new@test.com", "Bio", "https://avatar.url");
+        var dto = new CreateAuthorDto("Rani Maharani", "rani@contoh.com", "Content Creator", "https://foto.url");
 
         var result = await _authorService.CreateAsync(dto);
 
-        Assert.Equal("New Author", result.Name);
-        
+        result.Should().NotBeNull();
+        result.Name.Should().Be("Rani Maharani");
+
         _authorRepoMock.Verify(r => r.AddAsync(It.IsAny<Author>(), It.IsAny<CancellationToken>()), Times.Once);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task UpdateAsync_ShouldUpdateAuthor_WhenFound()
+    public async Task When_Update_Found_Should_UbahDataDanReturnDto()
     {
-        var author = CreateAuthor("Old Name");
-        var dto = new UpdateAuthorDto("Updated Name", "updated@test.com", "New Bio", "https://new.url");
+        var author = CreateAuthor("Nama Asli");
+        var dto = new UpdateAuthorDto("Nama Panggung", "panggung@contoh.com", "Artis", "https://baru.url");
 
         _authorRepoMock.Setup(r => r.GetByIdAsync(author.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(author);
 
         var result = await _authorService.UpdateAsync(author.Id, dto);
 
-        Assert.Equal("Updated Name", result!.Name);
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("Nama Panggung");
 
         _authorRepoMock.Verify(r => r.UpdateAsync(It.IsAny<Author>(), It.IsAny<CancellationToken>()), Times.Once);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task DeleteAsync_ShouldReturnTrue_WhenFound()
+    public async Task When_Delete_Found_Should_HapusDataDanReturnTrue()
     {
-        var author = CreateAuthor("To Delete");
+        var author = CreateAuthor("Penulis Tidak Aktif");
         _authorRepoMock.Setup(r => r.GetByIdAsync(author.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(author);
 
         var result = await _authorService.DeleteAsync(author.Id);
 
-        Assert.True(result);
+        result.Should().BeTrue();
         _authorRepoMock.Verify(r => r.DeleteAsync(author, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task When_Delete_NotFound_Should_ReturnFalse()
+    {
+        var id = Guid.NewGuid();
+        _authorRepoMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Author?)null);
+
+        var result = await _authorService.DeleteAsync(id);
+
+        result.Should().BeFalse();
+        _authorRepoMock.Verify(r => r.DeleteAsync(It.IsAny<Author>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     private static Author CreateAuthor(string name)
@@ -98,7 +113,7 @@ public class AuthorServiceTests
         {
             Id = Guid.NewGuid(),
             Name = name,
-            Email = $"{name.Replace(" ", "").ToLower()}@test.com",
+            Email = $"{name.ToLower().Replace(" ", ".")}@contoh.com",
             CreatedAt = DateTime.UtcNow
         };
     }

--- a/tests/Lexicon.Application.Tests/Services/CategoryServiceTests.cs
+++ b/tests/Lexicon.Application.Tests/Services/CategoryServiceTests.cs
@@ -10,135 +10,114 @@ namespace Lexicon.Application.Tests.Services;
 
 public class CategoryServiceTests
 {
-    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
-    private readonly Mock<ICategoryRepository> _categoryRepoMock;
-    private readonly CategoryService _categoryService;
+    private readonly CategoryService _svc;
+    private readonly Mock<ICategoryRepository> _catRepo;
+    private readonly Mock<IUnitOfWork> _uow;
 
     public CategoryServiceTests()
     {
-        _unitOfWorkMock = new Mock<IUnitOfWork>();
-        _categoryRepoMock = new Mock<ICategoryRepository>();
-
-        _unitOfWorkMock.Setup(u => u.Categories).Returns(_categoryRepoMock.Object);
-        _categoryService = new CategoryService(_unitOfWorkMock.Object);
+        _catRepo = new Mock<ICategoryRepository>();
+        _uow = new Mock<IUnitOfWork>();
+        _uow.Setup(x => x.Categories).Returns(_catRepo.Object);
+        _svc = new CategoryService(_uow.Object);
     }
 
-    [Fact]
-    public async Task When_GetAll_Should_ReturnSemuaKategori()
-    {
-        var categories = new List<Category> { CreateCategory("Elektronik"), CreateCategory("Peralatan Rumah") };
-        _categoryRepoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(categories);
-
-        var result = await _categoryService.GetAllAsync();
-
-        result.Should().HaveCount(2);
-        result.First().Name.Should().Be("Elektronik");
-    }
-
-    [Fact]
-    public async Task When_GetById_Found_Should_ReturnDataKategori()
-    {
-        var category = CreateCategory("Laptop Gaming");
-        _categoryRepoMock.Setup(r => r.GetByIdAsync(category.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(category);
-
-        var result = await _categoryService.GetByIdAsync(category.Id);
-
-        result.Should().NotBeNull();
-        result!.Id.Should().Be(category.Id);
-    }
-
-    [Fact]
-    public async Task When_GetBySlug_Found_Should_ReturnDataCategory()
-    {
-        var category = CreateCategory("Smartphone Terbaru");
-        _categoryRepoMock.Setup(r => r.GetBySlugAsync(category.Slug, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(category);
-
-        var result = await _categoryService.GetBySlugAsync(category.Slug);
-
-        result.Should().NotBeNull();
-        result!.Slug.Should().Be("smartphone-terbaru");
-    }
-
-    [Fact]
-    public async Task When_Create_WithValidData_Should_SimpanDanReturnDto()
-    {
-        var dto = new CreateCategoryDto("Kamera Digital", "Untuk fotografi", null);
-
-        var result = await _categoryService.CreateAsync(dto);
-
-        result.Should().NotBeNull();
-        result.Name.Should().Be("Kamera Digital");
-
-        _categoryRepoMock.Verify(r => r.AddAsync(It.IsAny<Category>(), It.IsAny<CancellationToken>()), Times.Once);
-        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
-    }
-
-    [Fact]
-    public async Task When_Update_Found_Should_UbahDataDanReturnDto()
-    {
-        var category = CreateCategory("Nama Lama");
-        var dto = new UpdateCategoryDto("Nama Baru", "Deskripsi Baru", null);
-
-        _categoryRepoMock.Setup(r => r.GetByIdAsync(category.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(category);
-
-        var result = await _categoryService.UpdateAsync(category.Id, dto);
-
-        result.Should().NotBeNull();
-        result!.Name.Should().Be("Nama Baru");
-
-        _categoryRepoMock.Verify(r => r.UpdateAsync(It.IsAny<Category>(), It.IsAny<CancellationToken>()), Times.Once);
-        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
-    }
-
-    [Fact]
-    public async Task When_Delete_Found_Should_HapusDataDanReturnTrue()
-    {
-        var category = CreateCategory("Kategori Sampah");
-        _categoryRepoMock.Setup(r => r.GetByIdAsync(category.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(category);
-
-        var result = await _categoryService.DeleteAsync(category.Id);
-
-        result.Should().BeTrue();
-        _categoryRepoMock.Verify(r => r.DeleteAsync(category, It.IsAny<CancellationToken>()), Times.Once);
-    }
-
-    [Fact]
-    public async Task When_GetTree_Should_ReturnStrukturHierarki()
-    {
-        var root = CreateCategory("Induk Perusahaan");
-        var child = CreateCategory("Divisi IT");
-        child.ParentId = root.Id;
-
-        _categoryRepoMock.Setup(r => r.GetRootCategoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { root });
-
-        _categoryRepoMock.Setup(r => r.GetChildrenAsync(root.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { child });
-
-        _categoryRepoMock.Setup(r => r.GetChildrenAsync(child.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Enumerable.Empty<Category>());
-
-        var result = await _categoryService.GetTreeAsync();
-
-        result.Should().HaveCount(1);
-        result.First().Children.Should().HaveCount(1);
-        result.First().Children.First().Name.Should().Be("Divisi IT");
-    }
-
-    private static Category CreateCategory(string name)
+    private Category BikinKategori(string nama, Guid? parentId = null)
     {
         return new Category
         {
             Id = Guid.NewGuid(),
-            Name = name,
-            Slug = name.ToLower().Replace(" ", "-"),
-            Description = "Deskripsi default",
+            Name = nama,
+            Slug = nama.ToLower().Replace(" ", "-"),
+            ParentId = parentId,
             CreatedAt = DateTime.UtcNow
         };
+    }
+
+    [Fact]
+    public async Task Ambil_SemuaKategori()
+    {
+        var list = new List<Category>
+        {
+            BikinKategori("Laporan Bulanan"),
+            BikinKategori("Surat Keluar")
+        };
+        _catRepo.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(list);
+
+        var result = await _svc.GetAllAsync();
+
+        result.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task Ambil_ById()
+    {
+        var kat = BikinKategori("Dokumen Teknis");
+        _catRepo.Setup(r => r.GetByIdAsync(kat.Id, It.IsAny<CancellationToken>())).ReturnsAsync(kat);
+
+        var result = await _svc.GetByIdAsync(kat.Id);
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("Dokumen Teknis");
+    }
+
+    [Fact]
+    public async Task Ambil_BySlug()
+    {
+        var kat = BikinKategori("Panduan Kerja");
+        _catRepo.Setup(r => r.GetBySlugAsync("panduan-kerja", default)).ReturnsAsync(kat);
+
+        var result = await _svc.GetBySlugAsync("panduan-kerja");
+        result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Tambah_KategoriBaru()
+    {
+        var dto = new CreateCategoryDto("Arsip Lama", "Dokumen lama perusahaan", null);
+
+        var result = await _svc.CreateAsync(dto);
+
+        result.Name.Should().Be("Arsip Lama");
+        _uow.Verify(x => x.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task Edit_KategoriYangAda()
+    {
+        var existing = BikinKategori("Nama Salah");
+        _catRepo.Setup(r => r.GetByIdAsync(existing.Id, It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+
+        var dto = new UpdateCategoryDto("Nama Benar", "Deskripsi diperbaiki", null);
+        var result = await _svc.UpdateAsync(existing.Id, dto);
+
+        result!.Name.Should().Be("Nama Benar");
+        _catRepo.Verify(r => r.UpdateAsync(It.IsAny<Category>(), It.IsAny<CancellationToken>()));
+    }
+
+    [Fact]
+    public async Task Hapus_Kategori_Berhasil()
+    {
+        var kat = BikinKategori("Kategori Usang");
+        _catRepo.Setup(r => r.GetByIdAsync(kat.Id, default)).ReturnsAsync(kat);
+
+        var ok = await _svc.DeleteAsync(kat.Id);
+        ok.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task TreeMainChild()
+    {
+        var main = BikinKategori("Kantor Pusat");
+        var child = BikinKategori("Cabang Surabaya", main.Id);
+
+        _catRepo.Setup(r => r.GetRootCategoriesAsync(default)).ReturnsAsync(new[] { main });
+        _catRepo.Setup(r => r.GetChildrenAsync(main.Id, default)).ReturnsAsync(new[] { child });
+        _catRepo.Setup(r => r.GetChildrenAsync(child.Id, default)).ReturnsAsync(Array.Empty<Category>());
+
+        var tree = await _svc.GetTreeAsync();
+
+        tree.Should().ContainSingle();
+        tree.First().Children.Should().ContainSingle()
+            .Which.Name.Should().Be("Cabang Surabaya");
     }
 }

--- a/tests/Lexicon.Application.Tests/Services/CategoryServiceTests.cs
+++ b/tests/Lexicon.Application.Tests/Services/CategoryServiceTests.cs
@@ -24,91 +24,94 @@ public class CategoryServiceTests
     }
 
     [Fact]
-    public async Task GetAllAsync_ShouldReturnAllCategories()
+    public async Task When_GetAll_Should_ReturnSemuaKategori()
     {
-        var categories = new List<Category> { CreateCategory("Tech"), CreateCategory("Life") };
+        var categories = new List<Category> { CreateCategory("Elektronik"), CreateCategory("Peralatan Rumah") };
         _categoryRepoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(categories);
 
         var result = await _categoryService.GetAllAsync();
 
         result.Should().HaveCount(2);
-        Assert.Equal("Tech", result.First().Name);
+        result.First().Name.Should().Be("Elektronik");
     }
 
     [Fact]
-    public async Task GetByIdAsync_ShouldReturnCategory_WhenFound()
+    public async Task When_GetById_Found_Should_ReturnDataKategori()
     {
-        var category = CreateCategory("Tech");
+        var category = CreateCategory("Laptop Gaming");
         _categoryRepoMock.Setup(r => r.GetByIdAsync(category.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(category);
 
         var result = await _categoryService.GetByIdAsync(category.Id);
 
-        Assert.NotNull(result);
-        result.Id.Should().Be(category.Id);
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(category.Id);
     }
 
     [Fact]
-    public async Task GetBySlugAsync_ShouldReturnCategory_WhenFound()
+    public async Task When_GetBySlug_Found_Should_ReturnDataCategory()
     {
-        var category = CreateCategory("Tech");
+        var category = CreateCategory("Smartphone Terbaru");
         _categoryRepoMock.Setup(r => r.GetBySlugAsync(category.Slug, It.IsAny<CancellationToken>()))
             .ReturnsAsync(category);
 
         var result = await _categoryService.GetBySlugAsync(category.Slug);
 
-        Assert.NotNull(result);
-        Assert.Equal(category.Slug, result.Slug);
+        result.Should().NotBeNull();
+        result!.Slug.Should().Be("smartphone-terbaru");
     }
 
     [Fact]
-    public async Task CreateAsync_ShouldCreateCategory()
+    public async Task When_Create_WithValidData_Should_SimpanDanReturnDto()
     {
-        var dto = new CreateCategoryDto("New Tech", "Description", null);
+        var dto = new CreateCategoryDto("Kamera Digital", "Untuk fotografi", null);
 
         var result = await _categoryService.CreateAsync(dto);
 
-        result.Name.Should().Be("New Tech");
+        result.Should().NotBeNull();
+        result.Name.Should().Be("Kamera Digital");
+
         _categoryRepoMock.Verify(r => r.AddAsync(It.IsAny<Category>(), It.IsAny<CancellationToken>()), Times.Once);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task UpdateAsync_ShouldUpdateCategory_WhenFound()
+    public async Task When_Update_Found_Should_UbahDataDanReturnDto()
     {
-        var category = CreateCategory("Old");
-        var dto = new UpdateCategoryDto("New Name", "New Desc", null);
+        var category = CreateCategory("Nama Lama");
+        var dto = new UpdateCategoryDto("Nama Baru", "Deskripsi Baru", null);
 
         _categoryRepoMock.Setup(r => r.GetByIdAsync(category.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(category);
 
         var result = await _categoryService.UpdateAsync(category.Id, dto);
 
-        Assert.Equal("New Name", result!.Name);
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("Nama Baru");
 
         _categoryRepoMock.Verify(r => r.UpdateAsync(It.IsAny<Category>(), It.IsAny<CancellationToken>()), Times.Once);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task DeleteAsync_ShouldReturnTrue_WhenFound()
+    public async Task When_Delete_Found_Should_HapusDataDanReturnTrue()
     {
-        var category = CreateCategory("To Delete");
+        var category = CreateCategory("Kategori Sampah");
         _categoryRepoMock.Setup(r => r.GetByIdAsync(category.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(category);
 
         var result = await _categoryService.DeleteAsync(category.Id);
 
-        Assert.True(result);
+        result.Should().BeTrue();
         _categoryRepoMock.Verify(r => r.DeleteAsync(category, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task GetTreeAsync_ShouldReturnHierarchicalStructure()
+    public async Task When_GetTree_Should_ReturnStrukturHierarki()
     {
-        var root = CreateCategory("Root");
-        var child = CreateCategory("Child");
+        var root = CreateCategory("Induk Perusahaan");
+        var child = CreateCategory("Divisi IT");
         child.ParentId = root.Id;
 
         _categoryRepoMock.Setup(r => r.GetRootCategoriesAsync(It.IsAny<CancellationToken>()))
@@ -123,7 +126,8 @@ public class CategoryServiceTests
         var result = await _categoryService.GetTreeAsync();
 
         result.Should().HaveCount(1);
-        Assert.Equal("Child", result.First().Children.First().Name);
+        result.First().Children.Should().HaveCount(1);
+        result.First().Children.First().Name.Should().Be("Divisi IT");
     }
 
     private static Category CreateCategory(string name)
@@ -132,8 +136,8 @@ public class CategoryServiceTests
         {
             Id = Guid.NewGuid(),
             Name = name,
-            Slug = name.ToLower(),
-            Description = "Desc",
+            Slug = name.ToLower().Replace(" ", "-"),
+            Description = "Deskripsi default",
             CreatedAt = DateTime.UtcNow
         };
     }

--- a/tests/Lexicon.Application.Tests/Services/CategoryServiceTests.cs
+++ b/tests/Lexicon.Application.Tests/Services/CategoryServiceTests.cs
@@ -1,0 +1,172 @@
+using FluentAssertions;
+using Lexicon.Application.DTOs;
+using Lexicon.Application.Services;
+using Lexicon.Domain.Entities;
+using Lexicon.Domain.Interfaces;
+using Moq;
+using Xunit;
+
+namespace Lexicon.Application.Tests.Services;
+
+public class CategoryServiceTests
+{
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<ICategoryRepository> _categoryRepositoryMock;
+    private readonly CategoryService _sut;
+
+    public CategoryServiceTests()
+    {
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _categoryRepositoryMock = new Mock<ICategoryRepository>();
+
+        _unitOfWorkMock.Setup(u => u.Categories).Returns(_categoryRepositoryMock.Object);
+
+        _sut = new CategoryService(_unitOfWorkMock.Object);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ShouldReturnAllCategories()
+    {
+        // Arrange
+        var categories = new List<Category>
+        {
+            new() { Id = Guid.NewGuid(), Name = "Tech", Slug = "tech" },
+            new() { Id = Guid.NewGuid(), Name = "Life", Slug = "life" }
+        };
+
+        _categoryRepositoryMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(categories);
+
+        // Act
+        var result = await _sut.GetAllAsync();
+
+        // Assert
+        result.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ShouldReturnCategory_WhenFound()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var category = new Category { Id = id, Name = "Tech", Slug = "tech" };
+
+        _categoryRepositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(category);
+
+        // Act
+        var result = await _sut.GetByIdAsync(id);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(id);
+    }
+
+    [Fact]
+    public async Task GetBySlugAsync_ShouldReturnCategory_WhenFound()
+    {
+        // Arrange
+        var slug = "tech";
+        var category = new Category { Id = Guid.NewGuid(), Name = "Tech", Slug = slug };
+
+        _categoryRepositoryMock.Setup(r => r.GetBySlugAsync(slug, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(category);
+
+        // Act
+        var result = await _sut.GetBySlugAsync(slug);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Slug.Should().Be(slug);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldCreateCategory()
+    {
+        // Arrange
+        var dto = new CreateCategoryDto("New Tech", "Description", null);
+
+        // Act
+        var result = await _sut.CreateAsync(dto);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Name.Should().Be("New Tech");
+        result.Slug.Should().Be("new-tech");
+
+        _categoryRepositoryMock.Verify(r => r.AddAsync(It.IsAny<Category>(), It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ShouldUpdateCategory_WhenFound()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var category = new Category { Id = id, Name = "Old", Slug = "old" };
+        var dto = new UpdateCategoryDto("New Name", "New Desc", null);
+
+        _categoryRepositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(category);
+
+        // Act
+        var result = await _sut.UpdateAsync(id, dto);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("New Name");
+        result.Slug.Should().Be("new-name");
+
+        _categoryRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<Category>(), It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ShouldReturnTrue_WhenFound()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var category = new Category { Id = id, Name = "To Delete" };
+
+        _categoryRepositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(category);
+
+        // Act
+        var result = await _sut.DeleteAsync(id);
+
+        // Assert
+        result.Should().BeTrue();
+        _categoryRepositoryMock.Verify(r => r.DeleteAsync(category, It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetTreeAsync_ShouldReturnHierarchicalStructure()
+    {
+        // Arrange
+        var rootId = Guid.NewGuid();
+        var childId = Guid.NewGuid();
+
+        var rootCategory = new Category { Id = rootId, Name = "Root", Slug = "root", ParentId = null };
+        var childCategory = new Category { Id = childId, Name = "Child", Slug = "child", ParentId = rootId };
+
+        _categoryRepositoryMock.Setup(r => r.GetRootCategoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { rootCategory });
+
+        _categoryRepositoryMock.Setup(r => r.GetChildrenAsync(rootId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { childCategory });
+
+        _categoryRepositoryMock.Setup(r => r.GetChildrenAsync(childId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Enumerable.Empty<Category>());
+
+        // Act
+        var result = await _sut.GetTreeAsync();
+
+        // Assert
+        result.Should().HaveCount(1);
+        var root = result.First();
+        root.Name.Should().Be("Root");
+        root.Children.Should().HaveCount(1);
+        root.Children.First().Name.Should().Be("Child");
+    }
+}

--- a/tests/Lexicon.Application.Tests/Services/CategoryServiceTests.cs
+++ b/tests/Lexicon.Application.Tests/Services/CategoryServiceTests.cs
@@ -11,162 +11,130 @@ namespace Lexicon.Application.Tests.Services;
 public class CategoryServiceTests
 {
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
-    private readonly Mock<ICategoryRepository> _categoryRepositoryMock;
-    private readonly CategoryService _sut;
+    private readonly Mock<ICategoryRepository> _categoryRepoMock;
+    private readonly CategoryService _categoryService;
 
     public CategoryServiceTests()
     {
         _unitOfWorkMock = new Mock<IUnitOfWork>();
-        _categoryRepositoryMock = new Mock<ICategoryRepository>();
+        _categoryRepoMock = new Mock<ICategoryRepository>();
 
-        _unitOfWorkMock.Setup(u => u.Categories).Returns(_categoryRepositoryMock.Object);
-
-        _sut = new CategoryService(_unitOfWorkMock.Object);
+        _unitOfWorkMock.Setup(u => u.Categories).Returns(_categoryRepoMock.Object);
+        _categoryService = new CategoryService(_unitOfWorkMock.Object);
     }
 
     [Fact]
     public async Task GetAllAsync_ShouldReturnAllCategories()
     {
-        // Arrange
-        var categories = new List<Category>
-        {
-            new() { Id = Guid.NewGuid(), Name = "Tech", Slug = "tech" },
-            new() { Id = Guid.NewGuid(), Name = "Life", Slug = "life" }
-        };
-
-        _categoryRepositoryMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+        var categories = new List<Category> { CreateCategory("Tech"), CreateCategory("Life") };
+        _categoryRepoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(categories);
 
-        // Act
-        var result = await _sut.GetAllAsync();
+        var result = await _categoryService.GetAllAsync();
 
-        // Assert
         result.Should().HaveCount(2);
+        Assert.Equal("Tech", result.First().Name);
     }
 
     [Fact]
     public async Task GetByIdAsync_ShouldReturnCategory_WhenFound()
     {
-        // Arrange
-        var id = Guid.NewGuid();
-        var category = new Category { Id = id, Name = "Tech", Slug = "tech" };
-
-        _categoryRepositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+        var category = CreateCategory("Tech");
+        _categoryRepoMock.Setup(r => r.GetByIdAsync(category.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(category);
 
-        // Act
-        var result = await _sut.GetByIdAsync(id);
+        var result = await _categoryService.GetByIdAsync(category.Id);
 
-        // Assert
-        result.Should().NotBeNull();
-        result!.Id.Should().Be(id);
+        Assert.NotNull(result);
+        result.Id.Should().Be(category.Id);
     }
 
     [Fact]
     public async Task GetBySlugAsync_ShouldReturnCategory_WhenFound()
     {
-        // Arrange
-        var slug = "tech";
-        var category = new Category { Id = Guid.NewGuid(), Name = "Tech", Slug = slug };
-
-        _categoryRepositoryMock.Setup(r => r.GetBySlugAsync(slug, It.IsAny<CancellationToken>()))
+        var category = CreateCategory("Tech");
+        _categoryRepoMock.Setup(r => r.GetBySlugAsync(category.Slug, It.IsAny<CancellationToken>()))
             .ReturnsAsync(category);
 
-        // Act
-        var result = await _sut.GetBySlugAsync(slug);
+        var result = await _categoryService.GetBySlugAsync(category.Slug);
 
-        // Assert
-        result.Should().NotBeNull();
-        result!.Slug.Should().Be(slug);
+        Assert.NotNull(result);
+        Assert.Equal(category.Slug, result.Slug);
     }
 
     [Fact]
     public async Task CreateAsync_ShouldCreateCategory()
     {
-        // Arrange
         var dto = new CreateCategoryDto("New Tech", "Description", null);
 
-        // Act
-        var result = await _sut.CreateAsync(dto);
+        var result = await _categoryService.CreateAsync(dto);
 
-        // Assert
-        result.Should().NotBeNull();
         result.Name.Should().Be("New Tech");
-        result.Slug.Should().Be("new-tech");
-
-        _categoryRepositoryMock.Verify(r => r.AddAsync(It.IsAny<Category>(), It.IsAny<CancellationToken>()), Times.Once);
+        _categoryRepoMock.Verify(r => r.AddAsync(It.IsAny<Category>(), It.IsAny<CancellationToken>()), Times.Once);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task UpdateAsync_ShouldUpdateCategory_WhenFound()
     {
-        // Arrange
-        var id = Guid.NewGuid();
-        var category = new Category { Id = id, Name = "Old", Slug = "old" };
+        var category = CreateCategory("Old");
         var dto = new UpdateCategoryDto("New Name", "New Desc", null);
 
-        _categoryRepositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+        _categoryRepoMock.Setup(r => r.GetByIdAsync(category.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(category);
 
-        // Act
-        var result = await _sut.UpdateAsync(id, dto);
+        var result = await _categoryService.UpdateAsync(category.Id, dto);
 
-        // Assert
-        result.Should().NotBeNull();
-        result!.Name.Should().Be("New Name");
-        result.Slug.Should().Be("new-name");
+        Assert.Equal("New Name", result!.Name);
 
-        _categoryRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<Category>(), It.IsAny<CancellationToken>()), Times.Once);
+        _categoryRepoMock.Verify(r => r.UpdateAsync(It.IsAny<Category>(), It.IsAny<CancellationToken>()), Times.Once);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task DeleteAsync_ShouldReturnTrue_WhenFound()
     {
-        // Arrange
-        var id = Guid.NewGuid();
-        var category = new Category { Id = id, Name = "To Delete" };
-
-        _categoryRepositoryMock.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+        var category = CreateCategory("To Delete");
+        _categoryRepoMock.Setup(r => r.GetByIdAsync(category.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(category);
 
-        // Act
-        var result = await _sut.DeleteAsync(id);
+        var result = await _categoryService.DeleteAsync(category.Id);
 
-        // Assert
-        result.Should().BeTrue();
-        _categoryRepositoryMock.Verify(r => r.DeleteAsync(category, It.IsAny<CancellationToken>()), Times.Once);
-        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        Assert.True(result);
+        _categoryRepoMock.Verify(r => r.DeleteAsync(category, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task GetTreeAsync_ShouldReturnHierarchicalStructure()
     {
-        // Arrange
-        var rootId = Guid.NewGuid();
-        var childId = Guid.NewGuid();
+        var root = CreateCategory("Root");
+        var child = CreateCategory("Child");
+        child.ParentId = root.Id;
 
-        var rootCategory = new Category { Id = rootId, Name = "Root", Slug = "root", ParentId = null };
-        var childCategory = new Category { Id = childId, Name = "Child", Slug = "child", ParentId = rootId };
+        _categoryRepoMock.Setup(r => r.GetRootCategoriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { root });
 
-        _categoryRepositoryMock.Setup(r => r.GetRootCategoriesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { rootCategory });
+        _categoryRepoMock.Setup(r => r.GetChildrenAsync(root.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { child });
 
-        _categoryRepositoryMock.Setup(r => r.GetChildrenAsync(rootId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { childCategory });
-
-        _categoryRepositoryMock.Setup(r => r.GetChildrenAsync(childId, It.IsAny<CancellationToken>()))
+        _categoryRepoMock.Setup(r => r.GetChildrenAsync(child.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Enumerable.Empty<Category>());
 
-        // Act
-        var result = await _sut.GetTreeAsync();
+        var result = await _categoryService.GetTreeAsync();
 
-        // Assert
         result.Should().HaveCount(1);
-        var root = result.First();
-        root.Name.Should().Be("Root");
-        root.Children.Should().HaveCount(1);
-        root.Children.First().Name.Should().Be("Child");
+        Assert.Equal("Child", result.First().Children.First().Name);
+    }
+
+    private static Category CreateCategory(string name)
+    {
+        return new Category
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            Slug = name.ToLower(),
+            Description = "Desc",
+            CreatedAt = DateTime.UtcNow
+        };
     }
 }

--- a/tests/Lexicon.Application.Tests/Services/TagServiceTests.cs
+++ b/tests/Lexicon.Application.Tests/Services/TagServiceTests.cs
@@ -1,0 +1,197 @@
+using FluentAssertions;
+using Lexicon.Application.DTOs;
+using Lexicon.Application.Services;
+using Lexicon.Domain.Entities;
+using Lexicon.Domain.Interfaces;
+using Moq;
+using Xunit;
+
+namespace Lexicon.Application.Tests.Services;
+
+public class TagServiceTests
+{
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<ITagRepository> _tagRepositoryMock;
+    private readonly TagService _sut;
+
+    public TagServiceTests()
+    {
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _tagRepositoryMock = new Mock<ITagRepository>();
+
+        _unitOfWorkMock.Setup(u => u.Tags).Returns(_tagRepositoryMock.Object);
+
+        _sut = new TagService(_unitOfWorkMock.Object);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ShouldReturnAllTags()
+    {
+        // Arrange
+        var tags = new List<Tag>
+        {
+            new() { Id = Guid.NewGuid(), Name = "Tag 1", Slug = "tag-1" },
+            new() { Id = Guid.NewGuid(), Name = "Tag 2", Slug = "tag-2" }
+        };
+
+        _tagRepositoryMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tags);
+
+        // Act
+        var result = await _sut.GetAllAsync();
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.First().Name.Should().Be("Tag 1");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ShouldReturnTag_WhenTagExists()
+    {
+        // Arrange
+        var tagId = Guid.NewGuid();
+        var tag = new Tag { Id = tagId, Name = "Test Tag", Slug = "test-tag" };
+
+        _tagRepositoryMock.Setup(r => r.GetByIdAsync(tagId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tag);
+
+        // Act
+        var result = await _sut.GetByIdAsync(tagId);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(tagId);
+        result.Name.Should().Be("Test Tag");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ShouldReturnNull_WhenTagDoesNotExist()
+    {
+        // Arrange
+        var tagId = Guid.NewGuid();
+
+        _tagRepositoryMock.Setup(r => r.GetByIdAsync(tagId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Tag?)null);
+
+        // Act
+        var result = await _sut.GetByIdAsync(tagId);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetBySlugAsync_ShouldReturnTag_WhenTagExists()
+    {
+        // Arrange
+        var slug = "test-tag";
+        var tag = new Tag { Id = Guid.NewGuid(), Name = "Test Tag", Slug = slug };
+
+        _tagRepositoryMock.Setup(r => r.GetBySlugAsync(slug, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tag);
+
+        // Act
+        var result = await _sut.GetBySlugAsync(slug);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Slug.Should().Be(slug);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldCreateTagAndReturnDto()
+    {
+        // Arrange
+        var dto = new CreateTagDto("New Tag");
+
+        // Act
+        var result = await _sut.CreateAsync(dto);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Name.Should().Be("New Tag");
+        result.Slug.Should().Be("new-tag");
+
+        _tagRepositoryMock.Verify(r => r.AddAsync(It.Is<Tag>(t => t.Name == "New Tag" && t.Slug == "new-tag"), It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ShouldUpdateTag_WhenTagExists()
+    {
+        // Arrange
+        var tagId = Guid.NewGuid();
+        var existingTag = new Tag { Id = tagId, Name = "Old Name", Slug = "old-name" };
+        var dto = new UpdateTagDto("Updated Name");
+
+        _tagRepositoryMock.Setup(r => r.GetByIdAsync(tagId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingTag);
+
+        // Act
+        var result = await _sut.UpdateAsync(tagId, dto);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("Updated Name");
+        result.Slug.Should().Be("updated-name");
+
+        _tagRepositoryMock.Verify(r => r.UpdateAsync(It.Is<Tag>(t => t.Name == "Updated Name"), It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ShouldReturnNull_WhenTagDoesNotExist()
+    {
+        // Arrange
+        var tagId = Guid.NewGuid();
+        var dto = new UpdateTagDto("Updated Name");
+
+        _tagRepositoryMock.Setup(r => r.GetByIdAsync(tagId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Tag?)null);
+
+        // Act
+        var result = await _sut.UpdateAsync(tagId, dto);
+
+        // Assert
+        result.Should().BeNull();
+        _tagRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<Tag>(), It.IsAny<CancellationToken>()), Times.Never);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ShouldReturnTrue_WhenTagExists()
+    {
+        // Arrange
+        var tagId = Guid.NewGuid();
+        var existingTag = new Tag { Id = tagId, Name = "Tag To Delete" };
+
+        _tagRepositoryMock.Setup(r => r.GetByIdAsync(tagId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingTag);
+
+        // Act
+        var result = await _sut.DeleteAsync(tagId);
+
+        // Assert
+        result.Should().BeTrue();
+        _tagRepositoryMock.Verify(r => r.DeleteAsync(existingTag, It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ShouldReturnFalse_WhenTagDoesNotExist()
+    {
+        // Arrange
+        var tagId = Guid.NewGuid();
+
+        _tagRepositoryMock.Setup(r => r.GetByIdAsync(tagId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Tag?)null);
+
+        // Act
+        var result = await _sut.DeleteAsync(tagId);
+
+        // Assert
+        result.Should().BeFalse();
+        _tagRepositoryMock.Verify(r => r.DeleteAsync(It.IsAny<Tag>(), It.IsAny<CancellationToken>()), Times.Never);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/tests/Lexicon.Application.Tests/Services/TagServiceTests.cs
+++ b/tests/Lexicon.Application.Tests/Services/TagServiceTests.cs
@@ -11,125 +11,128 @@ namespace Lexicon.Application.Tests.Services;
 public class TagServiceTests
 {
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
-    private readonly Mock<ITagRepository> _tagRepositoryMock;
+    private readonly Mock<ITagRepository> _tagRepoMock;
     private readonly TagService _tagService;
 
     public TagServiceTests()
     {
         _unitOfWorkMock = new Mock<IUnitOfWork>();
-        _tagRepositoryMock = new Mock<ITagRepository>();
+        _tagRepoMock = new Mock<ITagRepository>();
 
-        _unitOfWorkMock.Setup(u => u.Tags).Returns(_tagRepositoryMock.Object);
+        _unitOfWorkMock.Setup(u => u.Tags).Returns(_tagRepoMock.Object);
         _tagService = new TagService(_unitOfWorkMock.Object);
     }
 
     [Fact]
-    public async Task GetAllAsync_ShouldReturnAllTags()
+    public async Task When_GetAll_Should_ReturnDaftarTagLengkap()
     {
-        var tags = new List<Tag> { CreateTag("Tag 1"), CreateTag("Tag 2") };
-        _tagRepositoryMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+        var tags = new List<Tag> { CreateTag("Berita Teknologi"), CreateTag("Info Kesehatan") };
+        _tagRepoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(tags);
 
         var result = await _tagService.GetAllAsync();
 
         result.Should().HaveCount(2);
-        Assert.Equal("Tag 1", result.First().Name);
+        result.First().Name.Should().Be("Berita Teknologi");
     }
 
     [Fact]
-    public async Task GetByIdAsync_ShouldReturnTag_WhenTagExists()
+    public async Task When_GetById_Found_Should_ReturnDataTag()
     {
-        var tag = CreateTag("Test Tag");
-        _tagRepositoryMock.Setup(r => r.GetByIdAsync(tag.Id, It.IsAny<CancellationToken>()))
+        var tag = CreateTag("Tutorial Masak");
+        _tagRepoMock.Setup(r => r.GetByIdAsync(tag.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(tag);
 
         var result = await _tagService.GetByIdAsync(tag.Id);
 
         result.Should().NotBeNull();
-        Assert.Equal(tag.Id, result!.Id);
+        result!.Id.Should().Be(tag.Id);
+        result.Name.Should().Be("Tutorial Masak");
     }
 
     [Fact]
-    public async Task GetByIdAsync_ShouldReturnNull_WhenTagDoesNotExist()
+    public async Task When_GetById_NotFound_Should_ReturnNull()
     {
         var tagId = Guid.NewGuid();
-        _tagRepositoryMock.Setup(r => r.GetByIdAsync(tagId, It.IsAny<CancellationToken>()))
+        _tagRepoMock.Setup(r => r.GetByIdAsync(tagId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Tag?)null);
 
         var result = await _tagService.GetByIdAsync(tagId);
 
-        Assert.Null(result);
+        result.Should().BeNull();
     }
 
     [Fact]
-    public async Task GetBySlugAsync_ShouldReturnTag_WhenTagExists()
+    public async Task When_GetBySlug_Found_Should_ReturnDataTag()
     {
-        var tag = CreateTag("Test Tag");
-        _tagRepositoryMock.Setup(r => r.GetBySlugAsync(tag.Slug, It.IsAny<CancellationToken>()))
+        var tag = CreateTag("Tips Keuangan");
+        _tagRepoMock.Setup(r => r.GetBySlugAsync(tag.Slug, It.IsAny<CancellationToken>()))
             .ReturnsAsync(tag);
 
         var result = await _tagService.GetBySlugAsync(tag.Slug);
 
         result.Should().NotBeNull();
-        result!.Slug.Should().Be(tag.Slug);
+        result!.Slug.Should().Be("tips-keuangan");
     }
 
     [Fact]
-    public async Task CreateAsync_ShouldCreateTagAndReturnDto()
+    public async Task When_Create_WithValidData_Should_SimpanDanReturnDto()
     {
-        var dto = new CreateTagDto("New Tag");
+        var dto = new CreateTagDto("Loker Jakarta");
 
         var result = await _tagService.CreateAsync(dto);
 
         result.Should().NotBeNull();
-        Assert.Equal("New Tag", result.Name);
+        result.Name.Should().Be("Loker Jakarta");
+        result.Slug.Should().Be("loker-jakarta");
 
-        _tagRepositoryMock.Verify(r => r.AddAsync(It.Is<Tag>(t => t.Name == "New Tag"), It.IsAny<CancellationToken>()), Times.Once);
+        _tagRepoMock.Verify(r => r.AddAsync(It.Is<Tag>(t => t.Name == "Loker Jakarta"), It.IsAny<CancellationToken>()), Times.Once);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task UpdateAsync_ShouldUpdateTag_WhenTagExists()
+    public async Task When_Update_Found_Should_UbahDataDanReturnDto()
     {
-        var tag = CreateTag("Old Name");
-        var dto = new UpdateTagDto("Updated Name");
+        var tag = CreateTag("Nama Lama");
+        var dto = new UpdateTagDto("Nama Baru");
 
-        _tagRepositoryMock.Setup(r => r.GetByIdAsync(tag.Id, It.IsAny<CancellationToken>()))
+        _tagRepoMock.Setup(r => r.GetByIdAsync(tag.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(tag);
 
         var result = await _tagService.UpdateAsync(tag.Id, dto);
 
         result.Should().NotBeNull();
-        Assert.Equal("Updated Name", result!.Name);
+        result!.Name.Should().Be("Nama Baru");
 
-        _tagRepositoryMock.Verify(r => r.UpdateAsync(It.Is<Tag>(t => t.Name == "Updated Name"), It.IsAny<CancellationToken>()), Times.Once);
+        _tagRepoMock.Verify(r => r.UpdateAsync(It.Is<Tag>(t => t.Name == "Nama Baru"), It.IsAny<CancellationToken>()), Times.Once);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task DeleteAsync_ShouldReturnTrue_WhenTagExists()
+    public async Task When_Delete_Found_Should_HapusDataDanReturnTrue()
     {
-        var tag = CreateTag("Delete Me");
-        _tagRepositoryMock.Setup(r => r.GetByIdAsync(tag.Id, It.IsAny<CancellationToken>()))
+        var tag = CreateTag("Tag Sampah");
+        _tagRepoMock.Setup(r => r.GetByIdAsync(tag.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(tag);
 
         var result = await _tagService.DeleteAsync(tag.Id);
 
-        Assert.True(result);
-        _tagRepositoryMock.Verify(r => r.DeleteAsync(tag, It.IsAny<CancellationToken>()), Times.Once);
+        result.Should().BeTrue();
+        _tagRepoMock.Verify(r => r.DeleteAsync(tag, It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task DeleteAsync_ShouldReturnFalse_WhenTagDoesNotExist()
+    public async Task When_Delete_NotFound_Should_ReturnFalse()
     {
         var tagId = Guid.NewGuid();
-        _tagRepositoryMock.Setup(r => r.GetByIdAsync(tagId, It.IsAny<CancellationToken>()))
+        _tagRepoMock.Setup(r => r.GetByIdAsync(tagId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Tag?)null);
 
         var result = await _tagService.DeleteAsync(tagId);
 
-        Assert.False(result);
-        _tagRepositoryMock.Verify(r => r.DeleteAsync(It.IsAny<Tag>(), It.IsAny<CancellationToken>()), Times.Never);
+        result.Should().BeFalse();
+        _tagRepoMock.Verify(r => r.DeleteAsync(It.IsAny<Tag>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     private static Tag CreateTag(string name)

--- a/tests/Lexicon.Application.Tests/Services/TagServiceTests.cs
+++ b/tests/Lexicon.Application.Tests/Services/TagServiceTests.cs
@@ -10,138 +10,101 @@ namespace Lexicon.Application.Tests.Services;
 
 public class TagServiceTests
 {
-    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
-    private readonly Mock<ITagRepository> _tagRepoMock;
+    private readonly Mock<IUnitOfWork> _uow = new();
+    private readonly Mock<ITagRepository> _tagRepo = new();
     private readonly TagService _tagService;
 
     public TagServiceTests()
     {
-        _unitOfWorkMock = new Mock<IUnitOfWork>();
-        _tagRepoMock = new Mock<ITagRepository>();
-
-        _unitOfWorkMock.Setup(u => u.Tags).Returns(_tagRepoMock.Object);
-        _tagService = new TagService(_unitOfWorkMock.Object);
+        _uow.Setup(u => u.Tags).Returns(_tagRepo.Object);
+        _tagService = new TagService(_uow.Object);
     }
 
     [Fact]
-    public async Task When_GetAll_Should_ReturnDaftarTagLengkap()
+    public async Task GetAll()
     {
-        var tags = new List<Tag> { CreateTag("Berita Teknologi"), CreateTag("Info Kesehatan") };
-        _tagRepoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(tags);
-
-        var result = await _tagService.GetAllAsync();
-
-        result.Should().HaveCount(2);
-        result.First().Name.Should().Be("Berita Teknologi");
-    }
-
-    [Fact]
-    public async Task When_GetById_Found_Should_ReturnDataTag()
-    {
-        var tag = CreateTag("Tutorial Masak");
-        _tagRepoMock.Setup(r => r.GetByIdAsync(tag.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(tag);
-
-        var result = await _tagService.GetByIdAsync(tag.Id);
-
-        result.Should().NotBeNull();
-        result!.Id.Should().Be(tag.Id);
-        result.Name.Should().Be("Tutorial Masak");
-    }
-
-    [Fact]
-    public async Task When_GetById_NotFound_Should_ReturnNull()
-    {
-        var tagId = Guid.NewGuid();
-        _tagRepoMock.Setup(r => r.GetByIdAsync(tagId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Tag?)null);
-
-        var result = await _tagService.GetByIdAsync(tagId);
-
-        result.Should().BeNull();
-    }
-
-    [Fact]
-    public async Task When_GetBySlug_Found_Should_ReturnDataTag()
-    {
-        var tag = CreateTag("Tips Keuangan");
-        _tagRepoMock.Setup(r => r.GetBySlugAsync(tag.Slug, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(tag);
-
-        var result = await _tagService.GetBySlugAsync(tag.Slug);
-
-        result.Should().NotBeNull();
-        result!.Slug.Should().Be("tips-keuangan");
-    }
-
-    [Fact]
-    public async Task When_Create_WithValidData_Should_SimpanDanReturnDto()
-    {
-        var dto = new CreateTagDto("Loker Jakarta");
-
-        var result = await _tagService.CreateAsync(dto);
-
-        result.Should().NotBeNull();
-        result.Name.Should().Be("Loker Jakarta");
-        result.Slug.Should().Be("loker-jakarta");
-
-        _tagRepoMock.Verify(r => r.AddAsync(It.Is<Tag>(t => t.Name == "Loker Jakarta"), It.IsAny<CancellationToken>()), Times.Once);
-        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
-    }
-
-    [Fact]
-    public async Task When_Update_Found_Should_UbahDataDanReturnDto()
-    {
-        var tag = CreateTag("Nama Lama");
-        var dto = new UpdateTagDto("Nama Baru");
-
-        _tagRepoMock.Setup(r => r.GetByIdAsync(tag.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(tag);
-
-        var result = await _tagService.UpdateAsync(tag.Id, dto);
-
-        result.Should().NotBeNull();
-        result!.Name.Should().Be("Nama Baru");
-
-        _tagRepoMock.Verify(r => r.UpdateAsync(It.Is<Tag>(t => t.Name == "Nama Baru"), It.IsAny<CancellationToken>()), Times.Once);
-        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
-    }
-
-    [Fact]
-    public async Task When_Delete_Found_Should_HapusDataDanReturnTrue()
-    {
-        var tag = CreateTag("Tag Sampah");
-        _tagRepoMock.Setup(r => r.GetByIdAsync(tag.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(tag);
-
-        var result = await _tagService.DeleteAsync(tag.Id);
-
-        result.Should().BeTrue();
-        _tagRepoMock.Verify(r => r.DeleteAsync(tag, It.IsAny<CancellationToken>()), Times.Once);
-        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
-    }
-
-    [Fact]
-    public async Task When_Delete_NotFound_Should_ReturnFalse()
-    {
-        var tagId = Guid.NewGuid();
-        _tagRepoMock.Setup(r => r.GetByIdAsync(tagId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Tag?)null);
-
-        var result = await _tagService.DeleteAsync(tagId);
-
-        result.Should().BeFalse();
-        _tagRepoMock.Verify(r => r.DeleteAsync(It.IsAny<Tag>(), It.IsAny<CancellationToken>()), Times.Never);
-    }
-
-    private static Tag CreateTag(string name)
-    {
-        return new Tag
+        _tagRepo.Setup(r => r.GetAllAsync(default)).ReturnsAsync(new List<Tag>
         {
-            Id = Guid.NewGuid(),
-            Name = name,
-            Slug = name.ToLower().Replace(" ", "-")
-        };
+            new() { Id = Guid.NewGuid(), Name = "Berita Politik", Slug = "berita-politik" },
+            new() { Id = Guid.NewGuid(), Name = "Review Hp", Slug = "review-hp" }
+        });
+
+        var hasil = await _tagService.GetAllAsync();
+        hasil.Should().HaveCount(2);
+        hasil.First().Name.Should().Be("Berita Politik");
+    }
+
+    [Fact]
+    public async Task GetById()
+    {
+        var tagId = Guid.NewGuid();
+        var tag = new Tag { Id = tagId, Name = "Tutorial Masak", Slug = "tutorial-masak" };
+        _tagRepo.Setup(r => r.GetByIdAsync(tagId, default)).ReturnsAsync(tag);
+
+        var hasil = await _tagService.GetByIdAsync(tagId);
+
+        hasil.Should().NotBeNull();
+        hasil!.Name.Should().Be("Tutorial Masak");
+    }
+
+    [Fact]
+    public async Task GetByIdReturnNull()
+    {
+        var randomId = Guid.NewGuid();
+        _tagRepo.Setup(r => r.GetByIdAsync(randomId, default)).ReturnsAsync((Tag?)null);
+
+        var hasil = await _tagService.GetByIdAsync(randomId);
+        hasil.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetBySlug()
+    {
+        var tag = new Tag { Id = Guid.NewGuid(), Name = "Tips Freelance", Slug = "tips-freelance" };
+        _tagRepo.Setup(r => r.GetBySlugAsync("tips-freelance", default)).ReturnsAsync(tag);
+
+        var hasil = await _tagService.GetBySlugAsync("tips-freelance");
+        hasil.Should().NotBeNull();
+        hasil!.Slug.Should().Be("tips-freelance");
+    }
+
+    [Fact]
+    public async Task Create()
+    {
+        var input = new CreateTagDto("Lowongan Kerja");
+        var hasil = await _tagService.CreateAsync(input);
+
+        hasil.Name.Should().Be("Lowongan Kerja");
+
+        _tagRepo.Verify(r => r.AddAsync(
+            It.Is<Tag>(t => t.Name == "Lowongan Kerja"),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Update()
+    {
+        var existing = new Tag { Id = Guid.NewGuid(), Name = "Nama Lama", Slug = "nama-lama" };
+        _tagRepo.Setup(r => r.GetByIdAsync(existing.Id, default)).ReturnsAsync(existing);
+
+        var hasil = await _tagService.UpdateAsync(existing.Id, new UpdateTagDto("Nama Baru"));
+
+        hasil.Should().NotBeNull();
+        hasil!.Name.Should().Be("Nama Baru");
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()));
+    }
+
+    [Fact]
+    public async Task Delete()
+    {
+        var tag = new Tag { Id = Guid.NewGuid(), Name = "Hapus Ini", Slug = "hapus-ini" };
+        _tagRepo.Setup(r => r.GetByIdAsync(tag.Id, default)).ReturnsAsync(tag);
+
+        var berhasil = await _tagService.DeleteAsync(tag.Id);
+
+        berhasil.Should().BeTrue();
+        _tagRepo.Verify(r => r.DeleteAsync(tag, It.IsAny<CancellationToken>()), Times.Once);
     }
 }


### PR DESCRIPTION
Halo @bimakw 
Ini aku udah kerjain unit test buat service yang lebih simpel dulu sesuai saran di Issue #13.
**Yang aku kerjain:**
*   Nambahin library `Moq` ke project test buat mocking [IUnitOfWork](cci:2://file:///d:/Belajar/lexicon/src/Lexicon.Domain/Interfaces/IUnitOfWork.cs:2:0-12:1) sama Repository.
*   Bikin unit test comprehensive (Happy path & Error path) buat:
    *   [TagService](cci:1://file:///d:/Belajar/lexicon/src/Lexicon.Application/Services/TagService.cs:10:4-13:5): CRUD + GetBySlug.
    *   [CategoryService](cci:2://file:///d:/Belajar/lexicon/src/Lexicon.Application/Services/CategoryService.cs:6:0-133:1): CRUD + GetTree (hierarki).
    *   [AuthorService](cci:1://file:///d:/Belajar/lexicon/src/Lexicon.Application/Services/AuthorService.cs:10:4-13:5): CRUD.
**Testing:**
Aku udah jalanin command ini di local dan hasilnya aman (*passed* semua):
```bash
dotnet test tests/Lexicon.Application.Tests